### PR TITLE
Atomically overwrite a file

### DIFF
--- a/src/main/java/hudson/plugins/distfork/DistForkCommand.java
+++ b/src/main/java/hudson/plugins/distfork/DistForkCommand.java
@@ -154,8 +154,14 @@ public class DistForkCommand extends CLICommand {
 
                         if (!returnFiles.isEmpty() || returnZip!=null) {
                             stderr.println("Copying back files");
-                            for (Entry<String, String> e : returnFiles.entrySet())
-                                workDir.child(e.getValue()).copyToWithPermission(new FilePath(channel,e.getKey()));
+                            for (Entry<String, String> e : returnFiles.entrySet()) {
+                                FilePath tmp = new FilePath(channel, e.getKey() + ".tmp");
+                                FilePath actual = new FilePath(channel, e.getKey());
+                                workDir.child(e.getValue()).copyToWithPermission(tmp);
+                                if (actual.exists())
+                                    actual.delete();
+                                tmp.renameTo(actual);
+                            }
 
                             if (returnZip!=null) {
                                 OutputStream os = new BufferedOutputStream(new FilePath(channel,returnZip).write());


### PR DESCRIPTION
If a copy operation fails, for example because the source file doesn't
exist, the current code leaves a 0-length file.

The presence of such 0-length file can trip up tools like make. It's
better to copy into another temporary file, then only after making sure
that the copy is successful, place the file in its intended name.

@reviewbybees 