### PR TITLE
Fixes SCM url property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/distfork-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/distfork-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/m2release-plugin/distfork-plugin.git</url>
+    <url>https://github.com/jenkinsci/distfork-plugin.git</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
The plugin is not within M2Release plugin repository but live in its own repository.
This create a problem in the update-center project that the URL to this plugin is pointing to the M2Repository repository (see https://plugins.jenkins.io/distfork "GitHub" link)

This issue was introduced in https://github.com/jenkinsci/distfork-plugin/commit/8cf8d3495c746a442a3c92d1f3de0c8266f3d2a5

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
