### PR TITLE
chore(Jenkinsfile) fix Windows build label to ensure agents are allocated on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(
   platforms: [
     'linux',
-    'maven-windows' // TODO Docker-based tests fail when using Docker on Windows. The maven-windows agents do not have Docker installed so tests that require Docker are skipped.
+    'maven-11-windows' // TODO Docker-based tests fail when using Docker on Windows. The maven-windows agents do not have Docker installed so tests that require Docker are skipped.
   ],
   jdkVersions: [11],
 )


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/documentation/blob/main/ci.adoc#tools-labels which changed a few months ago

Otherwise the builds are stuck for the Windows part. We deprecated the `maven-windows` label recently to ensure the major JDK required for building is specified through label as an explicit measure.
